### PR TITLE
Feature/capture parallel set exceptions

### DIFF
--- a/lib/rye/set.rb
+++ b/lib/rye/set.rb
@@ -170,11 +170,18 @@ module Rye
         end
       end
 
-      # Should it bubble up the exception for a single box? socket errors?
       threads.each do |t|
-        Kernel.sleep 0.03     # Give the thread some breathing room
-        t.join                # Wait for the thread to finish
-        raps << t[:rap]       # Grab the result
+        Kernel.sleep 0.03 # Give the thread some breathing room
+
+        begin
+          t.join # Wait for the thread to finish
+        rescue Exception => ex
+          # Store the exception in the result
+          raps << Rap.new(self, [ex])
+          next
+        end
+
+        raps << t[:rap] # Grab the result
       end
 
       raps


### PR DESCRIPTION
If I ran into a timeout or other exception when running commands via Rye::Set in parallel, it would prevent me from getting results for the rest of the boxes in the set. 

This change saves any exceptions in a Rye::Rap and appends it to the results.

Wasn't clear on how your test suite works. I'll gladly add tests if you could provide some guidance.
