### PR TITLE
Fix gem build for 0.9.8 and missing bin/ files

### DIFF
--- a/rye.gemspec
+++ b/rye.gemspec
@@ -1,7 +1,7 @@
 @spec = Gem::Specification.new do |s|
   s.name = "rye"
   s.rubyforge_project = "rye"
-  s.version = "0.9.7"
+  s.version = "0.9.8"
   s.summary = "Rye: Safely run SSH commands on a bunch of machines at the same time (from Ruby)."
   s.description = s.summary
   s.author = "Delano Mandelbaum"
@@ -36,8 +36,6 @@
   README.rdoc
   Rakefile
   Rudyfile
-  bin/try
-  bin/rye
   lib/esc.rb
   lib/rye.rb
   lib/rye/box.rb


### PR DESCRIPTION
Just a quick fix to make the Gem build after removing the /bin/\* files and incrementing the version in the spec i.a.w. the CHANGES.txt
