### PR TITLE
Stderr channel from Net:SSH:Buffer not being read from correctly.  Error messages from Rye::Set commands are lost. 

### DIFF
--- a/lib/rye/box.rb
+++ b/lib/rye/box.rb
@@ -817,6 +817,8 @@ module Rye
         rap.cmd = cmd_clean
         
         channel = net_ssh_exec!(cmd_internal, &blk)
+        channel[:stderr].position = 0
+        channel[:stdout].position = 0
         
         if channel[:exception]
           rap = channel[:exception].rap


### PR DESCRIPTION
I'm using Rye::Set and std error from commands are not being stored in the Rap correctly.  This issue is that the code (line 826, 827 in box.rb):

rap.add_stdout(channel[:stdout].read || '')
rap.add_stderr(channel[:stderr].read || '')

is reading from the end of the Net:SSH:Buffer object (channel).  I've added the code necessary to fix this in this pull request.

Thanks!
