### PR TITLE
Raise Net::SSH::HostKeyMismatch

### DIFF
--- a/lib/rye/box.rb
+++ b/lib/rye/box.rb
@@ -671,12 +671,7 @@ module Rye
       rescue Net::SSH::HostKeyMismatch => ex
         STDERR.puts ex.message
         print "\a" if @rye_info # Ring the bell
-        if highline.ask("Continue? ").strip.match(/\Ay|yes|sure|ya\z/i)
-          @rye_opts[:paranoid] = false
-          retry
-        else
-          raise Net::SSH::HostKeyMismatch
-        end
+        raise Net::SSH::HostKeyMismatch
       rescue Net::SSH::AuthenticationFailed => ex
         print "\a" if retried == 0 && @rye_info # Ring the bell once
         retried += 1


### PR DESCRIPTION
Instead of waiting for user input and disable host verification
