### PR TITLE
Propagate original HostKeyMismatch exception

### DIFF
--- a/lib/rye/box.rb
+++ b/lib/rye/box.rb
@@ -671,7 +671,7 @@ module Rye
       rescue Net::SSH::HostKeyMismatch => ex
         STDERR.puts ex.message
         print "\a" if @rye_info # Ring the bell
-        raise Net::SSH::HostKeyMismatch
+        raise ex
       rescue Net::SSH::AuthenticationFailed => ex
         print "\a" if retried == 0 && @rye_info # Ring the bell once
         retried += 1


### PR DESCRIPTION
Currently the HostKeyMismatch exception does not contain the details (host, port, etc.) since the original exception is not propagated. This fix re-raises the same exception after ringing the bell.
