### PR TITLE
Propagate original Net::SSH::AuthenticationFailed exception

### DIFF
--- a/lib/rye/box.rb
+++ b/lib/rye/box.rb
@@ -681,14 +681,14 @@ module Rye
         # Raise Net::SSH::AuthenticationFailed if publickey is the 
         # only auth method
         if @rye_opts[:auth_methods] == ["publickey"]
-          raise Net::SSH::AuthenticationFailed
+          raise ex
         elsif @rye_password_prompt && (STDIN.tty? && retried <= 3)
           STDERR.puts "Passwordless login failed for #{@rye_user}"
           @rye_opts[:password] = highline.ask("Password: ") { |q| q.echo = '' }.strip
           @rye_opts[:auth_methods].push *['keyboard-interactive', 'password']
           retry
         else
-          raise Net::SSH::AuthenticationFailed
+          raise ex
         end
       end
       


### PR DESCRIPTION
Currently the AuthenticationFailed exception does not contain the details (host, port, etc.) since the original exception is not propagated. This fix re-raises the same exception where applicable, instead of creating a new blank one.
