### PR TITLE
Propogate AuthenticationFailed and HostKeyMismatch exceptions for Rye::H...

### DIFF
--- a/lib/rye/hop.rb
+++ b/lib/rye/hop.rb
@@ -273,7 +273,7 @@ module Rye
           @rye_opts[:paranoid] = false
           retry
         else
-          raise Net::SSH::HostKeyMismatch
+          raise ex
         end
       rescue Net::SSH::AuthenticationFailed => ex
         print "\a" if retried == 0 && @rye_info # Ring the bell once
@@ -285,7 +285,7 @@ module Rye
           @rye_opts[:auth_methods].push *['keyboard-interactive', 'password']
           retry
         else
-          raise Net::SSH::AuthenticationFailed
+          raise ex
         end
       end
       


### PR DESCRIPTION
Sorry, I missed the escape propagation issues in `hop.rb`. Applies the same fixes as #39 and #40

Thanks
