### PR TITLE
Module should be Rye::Cmd not Rye::Box::Cmd it appears

### DIFF
--- a/lib/rye/cmd.rb
+++ b/lib/rye/cmd.rb
@@ -11,7 +11,7 @@ module Rye;
   # with mixins. 
   #
   #     require 'rye'
-  #     module Rye::Box::Cmd
+  #     module Rye::Cmd
   #       def special(*args); run_command("/your/special/command", args); end
   #     end
   #


### PR DESCRIPTION
This closes https://github.com/delano/rye/issues/44
