### PR TITLE
Don't force the output of stderr

### DIFF
--- a/lib/rye/box.rb
+++ b/lib/rye/box.rb
@@ -1097,7 +1097,7 @@ module Rye
         end
         channel.on_process                { 
           channel[:handler] = :on_process
-          STDERR.print channel[:stderr].read if channel[:stderr].available > 0
+          #STDERR.print channel[:stderr].read if channel[:stderr].available > 0
           begin
             send("state_#{channel[:state]}", channel) unless channel[:state].nil?
           rescue Interrupt

--- a/rye.gemspec
+++ b/rye.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Delano Mandelbaum"]
-  s.cert_chain = ["gem-public_cert.pem"]
+  #s.cert_chain = ["gem-public_cert.pem"]
   s.date = "2013-11-11"
   s.license = 'MIT'
   s.description = "Run SSH commands on a bunch of machines at the same time (from Ruby)."
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     "Rakefile",
     "Rudyfile",
     "VERSION",
-    "gem-public_cert.pem",
+    #"gem-public_cert.pem",
     "lib/esc.rb",
     "lib/rye.rb",
     "lib/rye/box.rb",
@@ -69,7 +69,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubyforge_project = "rye"
   s.rubygems_version = "1.8.23"
-  s.signing_key = "/etc/certs/gem-private_key.pem"
+  #s.signing_key = "/etc/certs/gem-private_key.pem"
   s.summary = "Run SSH commands on a bunch of machines at the same time (from Ruby)."
 
   if s.respond_to? :specification_version then


### PR DESCRIPTION
Let the user handle stderr display if needed when executing commands. It allows for a cleaner output and a better control of what's displayed when building cli applications.
