### PR TITLE
string_upload fails silently

### DIFF
--- a/lib/rye/cmd.rb
+++ b/lib/rye/cmd.rb
@@ -176,7 +176,7 @@ module Rye;
     #
     # Returns a String containing the content of all remote *paths*. 
     def string_download(*paths)
-      net_scp_transfer!(:download, *paths).string
+      net_scp_transfer!(:download, false, *paths).string
     end
     alias_method :str_download, :string_download
     


### PR DESCRIPTION
Hi,
I've recently started using Rye (thanks for the great work, by the way) and noticed that Cmd#string_upload fails silently. 

After some digging I found that Box#net_scp_transfer! requires an recursive argument, which string_upload does not pass (thus net_scp_transfer takes the passed paths as the recursive argument, and the empty array as paths) resulting in no uploads. This is fixed in commit 3938059.

Commit 607ce23 fixes the same problem for Cmd#string_download.

If you require any further changes before including my fixes, please let me know, I'd be happy to help.

Best regards,
  Christian
