### PR TITLE
stdout_hook returns without user/host information

### DIFF
--- a/lib/rye/box.rb
+++ b/lib/rye/box.rb
@@ -1069,7 +1069,7 @@ module Rye
         }
         channel.on_data                   { |ch, data| 
           channel[:handler] = ":on_data"
-          @rye_stdout_hook.call(data) if !@rye_pty && !@rye_quiet && @rye_stdout_hook.kind_of?(Proc)
+          @rye_stdout_hook.call(data, user, host, nickname) if !@rye_pty && !@rye_quiet && @rye_stdout_hook.kind_of?(Proc)
           if rye_pty && data =~ /password/i
             channel[:prompt] = data
             channel[:state] = :await_input


### PR DESCRIPTION
The exception_hook is called with the user & hostname passed to it -- thats useful when working with a Rye::Set.

'cmd_clean' isn't exposed in the create_channel method, so this is the simplest way I could think to bring some uniformity to the callbacks.
