### PR TITLE
Updated stty session state save to check for an interactive terminal

### DIFF
--- a/lib/rye/box.rb
+++ b/lib/rye/box.rb
@@ -155,8 +155,8 @@ module Rye
       @rye_password_prompt = @rye_opts.delete(:password_prompt)
 
       # Store the state of the terminal
-      @rye_stty_save = `stty -g`.chomp if STDIN.tty? 
-      
+      @rye_stty_save = `stty -g`.chomp if STDIN.tty? rescue nil 
+     
       unless @rye_templates.nil?
         require @rye_templates.to_s   # should be :erb
       end

--- a/lib/rye/hop.rb
+++ b/lib/rye/hop.rb
@@ -123,7 +123,7 @@ module Rye
       @rye_templates = @rye_opts.delete(:templates)
       
       # Store the state of the terminal 
-      @rye_stty_save = `stty -g`.chomp if STDIN.tty? 
+      @rye_stty_save = `stty -g`.chomp if STDIN.tty? rescue nil 
       
       unless @rye_templates.nil?
         require @rye_templates.to_s   # should be :erb


### PR DESCRIPTION
This prevents stty throwing errors (like 'stty: standard input: Invalid argument') in the output when run in a non-interactive session (like via Jenkins).
