### PR TITLE
gemspec: Made it ignore the private key, we don/'t build/publish it as a...

### DIFF
--- a/rye.gemspec
+++ b/rye.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubyforge_project = "rye"
   s.rubygems_version = "1.8.23"
-  s.signing_key = "/etc/certs/gem-private_key.pem"
+  s.signing_key = "/etc/certs/gem-private_key.pem" if $0 =~ /gem\z/
   s.summary = "Run SSH commands on a bunch of machines at the same time (from Ruby)."
 
   if s.respond_to? :specification_version then


### PR DESCRIPTION
Hi,
I wanted to install rye from your github via an entry in my Gemfile like this:

gem "rye", :github => 'delano/rye', :ref => 'abcdef123'

But: bundler install complained about your missing private key.

So I modified your gemspec that it will not try to sign, if it is installed directly.

rgds,
j
