### PR TITLE
Close SSH connections on `Timeout::Error`.

### DIFF
--- a/lib/rye/box.rb
+++ b/lib/rye/box.rb
@@ -719,6 +719,7 @@ module Rye
           @rye_via.disconnect
         end
       rescue SystemCallError, Timeout::Error => ex
+        @rye_ssh.close if @rye_ssh
         error "Rye::Box: Disconnect timeout (#{ex.message})"
         debug ex.backtrace
       rescue Interrupt

--- a/lib/rye/hop.rb
+++ b/lib/rye/hop.rb
@@ -334,6 +334,7 @@ module Rye
           @rye_via.disconnect
         end
       rescue SystemCallError, Timeout::Error => ex
+        @rye_ssh.close if @rye_ssh
         error "Rye::Hop: Disconnect timeout (#{ex.message})"
         debug ex.backtrace
       rescue Interrupt


### PR DESCRIPTION
Sometimes we connect to a lot of different servers and for some unknown reason the connection gets stuck. On Honeybadger all I can see are some Timeout errors, so this PR should fix the issue.
