### PR TITLE
remove Timeout.timeout (for review)

### DIFF
--- a/lib/rye.rb
+++ b/lib/rye.rb
@@ -14,7 +14,6 @@ require 'net/scp'
 require 'openssl'
 require 'tempfile'
 require 'highline'
-require 'timeout'
 
 require 'storable'
 require 'sysinfo'
@@ -314,7 +313,3 @@ module Rye
   Rye.reload
 
 end
-
-
-
-

--- a/lib/rye/box.rb
+++ b/lib/rye/box.rb
@@ -5,7 +5,7 @@ require 'readline'
 
 module Rye
   DEBUG = false unless defined?(Rye::DEBUG)
-  
+
   # = Rye::Box
   #
   # The Rye::Box class represents a machine. All system
@@ -18,7 +18,7 @@ module Rye
   #
   # You can also run local commands through SSH
   #
-  #     rbox = Rye::Box.new('localhost') 
+  #     rbox = Rye::Box.new('localhost')
   #     rbox.hostname   # => localhost
   #     rbox.uname(:a)  # => Darwin vanya 9.6.0 ...
   #
@@ -26,63 +26,63 @@ module Rye
   # * When anything confusing happens, enable debug in initialize
   # by passing :debug => STDERR. This will output Rye debug info
   # as well as Net::SSH info. This is VERY helpful for figuring
-  # out why some command is hanging or otherwise acting weird. 
+  # out why some command is hanging or otherwise acting weird.
   # * If a remote command is hanging, it's probably because a
-  # Net::SSH channel is waiting on_extended_data (a prompt). 
+  # Net::SSH channel is waiting on_extended_data (a prompt).
   #++
-  class Box 
+  class Box
     include Rye::Cmd
-    
+
     attr_accessor :rye_shell
     attr_accessor :rye_pty
-    
+
     def host; @rye_host; end
     def opts; @rye_opts; end
     def safe; @rye_safe; end
     def user; @rye_user; end
     def root?; user.to_s == "root" end
-    
+
     def templates; @rye_templates; end
-    def templates?; !@rye_templates.nil?; end 
-    
+    def templates?; !@rye_templates.nil?; end
+
     def enable_sudo; @rye_sudo = true; end
     def disable_sudo; @rye_sudo = false; end
     def sudo?; @rye_sudo == true end
-    
+
     # Returns the current value of the stash +@rye_stash+
     def stash; @rye_stash; end
     def quiet; @rye_quiet; end
     def via; @rye_via; end
     def nickname; @rye_nickname || host; end
-    
+
     def host=(val); @rye_host = val; end
     def opts=(val); @rye_opts = val; end
     def via=(val); @rye_via = val; end
-    
+
     # Store a value to the stash +@rye_stash+
     def stash=(val); @rye_stash = val; end
     def nickname=(val); @rye_nickname = val; end
-    
+
     def enable_safe_mode;  @rye_safe = true; end
     def disable_safe_mode; @rye_safe = false; end
     def safe?; @rye_safe == true; end
-    
+
     def enable_quiet_mode;  @rye_quiet = true; end
     def disable_quiet_mode; @rye_quiet = false; end
-    
+
     # The most recent value from Box.cd or Box.[]
     def current_working_directory; @rye_current_working_directory; end
 
     # The most recent valud for umask (or 0022)
     def current_umask; @rye_current_umask; end
-    
+
     def via?; !@rye_via.nil?; end
     def info?; !@rye_info.nil?; end
     def debug?; !@rye_debug.nil?; end
     def error?; !@rye_error.nil?; end
-    
-    def ostype=(val); @rye_ostype = val; end 
-    def impltype=(val); @rye_impltype = val; end 
+
+    def ostype=(val); @rye_ostype = val; end
+    def impltype=(val); @rye_impltype = val; end
     def pre_command_hook=(val); @rye_pre_command_hook = val; end
     def stdout_hook=(val); @rye_stdout_hook = val; end
     def post_command_hook=(val); @rye_post_command_hook = val; end
@@ -108,14 +108,14 @@ module Rye
     # * :sudo => Run all commands via sudo (default: false)
     # * :password_prompt => Show a password prompt on auth failure (default: true)
     #
-    # NOTE: +opts+ can also contain any parameter supported by 
+    # NOTE: +opts+ can also contain any parameter supported by
     # Net::SSH.start that is not already mentioned above.
     #
     def initialize(host='localhost', opts={})
       ssh_opts = ssh_config_options(host)
       @rye_exception_hook = {}
       @rye_host = host
-      
+
       if opts[:user]
         @rye_user = opts[:user]
       else
@@ -136,16 +136,16 @@ module Rye
         :quiet => false,
         :password_prompt => true
       }.merge(opts)
-      
+
       # Close the SSH session before Ruby exits. This will do nothing
-      # if disconnect has already been called explicitly. 
+      # if disconnect has already been called explicitly.
       at_exit { self.disconnect }
 
       # Properly handle whether the opt :via is a +Rye::Hop+ or a +String+
       via_hop(@rye_opts.delete(:via))
-      
+
       # @rye_opts gets sent to Net::SSH so we need to remove the keys
-      # that are not meant for it. 
+      # that are not meant for it.
       @rye_safe, @rye_debug = @rye_opts.delete(:safe), @rye_opts.delete(:debug)
       @rye_info, @rye_error = @rye_opts.delete(:info), @rye_opts.delete(:error)
       @rye_getenv = {} if @rye_opts.delete(:getenv) # Enable getenv with a hash
@@ -156,43 +156,43 @@ module Rye
 
       # Store the state of the terminal
       @rye_stty_save = `stty -g 2>/dev/null`.chomp rescue nil
-      
+
       unless @rye_templates.nil?
         require @rye_templates.to_s   # should be :erb
       end
-      
+
       @rye_opts[:logger] = Logger.new(@rye_debug) if @rye_debug # Enable Net::SSH debugging
       @rye_opts[:paranoid] ||= true unless @rye_safe == false # See Net::SSH.start
       @rye_opts[:keys] = [@rye_opts[:keys]].flatten.compact
-      
+
       # Just in case someone sends a true value rather than IO object
       @rye_debug = STDERR if @rye_debug == true || DEBUG
       @rye_error = STDERR if @rye_error == true
       @rye_info = STDOUT if @rye_info == true
-      
+
       # Add the given private keys to the keychain that will be used for @rye_host
       add_keys(@rye_opts[:keys])
-      
+
       # We don't want Net::SSH to handle the keypairs. This may change
-      # but for we're letting ssh-agent do it. 
-      # TODO: Check if this should ot should not be enabled. 
+      # but for we're letting ssh-agent do it.
+      # TODO: Check if this should ot should not be enabled.
       #@rye_opts.delete(:keys)
-      
+
       # From: capistrano/lib/capistrano/cli.rb
       STDOUT.sync = true # so that Net::SSH prompts show up
-      
+
       debug "ssh-agent info: #{Rye.sshagent_info.inspect}"
       debug @rye_opts.inspect
 
     end
-    
+
     # Parse SSH config files for use with Net::SSH
     def ssh_config_options(host)
       return Net::SSH::Config.for(host)
     end
-    
-    # * +hops+ Rye::Hop objects will be added directly 
-    # to the set. Hostnames will be used to create new instances of Rye::Hop 
+
+    # * +hops+ Rye::Hop objects will be added directly
+    # to the set. Hostnames will be used to create new instances of Rye::Hop
     # h1 = Rye::Hop.new "host1"
     # h1.via_hop "host2", :user => "service_user"
     #
@@ -203,7 +203,7 @@ module Rye
     # h1.via_hop h2
     #
     def via_hop(*args)
-      args = args.flatten.compact 
+      args = args.flatten.compact
       if args.first.nil?
         return @rye_via
       elsif args.first.is_a?(Rye::Hop)
@@ -224,20 +224,20 @@ module Rye
       self
     end
 
-    # Change the current working directory (sort of). 
+    # Change the current working directory (sort of).
     #
-    # I haven't been able to wrangle Net::SSH to do my bidding. 
+    # I haven't been able to wrangle Net::SSH to do my bidding.
     # "My bidding" in this case, is maintaining an open channel between commands.
     # I'm using Net::SSH::Connection::Session#exec for all commands
     # which is like a funky helper method that opens a new channel
-    # each time it's called. This seems to be okay for one-off 
+    # each time it's called. This seems to be okay for one-off
     # commands but changing the directory only works for the channel
     # it's executed in. The next time exec is called, there's a
-    # new channel which is back in the default (home) directory. 
+    # new channel which is back in the default (home) directory.
     #
     # Long story short, the work around is to maintain the current
-    # directory locally and send it with each command. 
-    # 
+    # directory locally and send it with each command.
+    #
     #     rbox.pwd              # => /home/rye ($ pwd )
     #     rbox['/usr/bin'].pwd  # => /usr/bin  ($ cd /usr/bin && pwd)
     #     rbox.pwd              # => /usr/bin  ($ cd /usr/bin && pwd)
@@ -258,27 +258,27 @@ module Rye
       self
     end
     # Like [] except it returns an empty Rye::Rap object to mimick
-    # a regular command method. Call with nil key (or no arg) to 
-    # reset. 
+    # a regular command method. Call with nil key (or no arg) to
+    # reset.
     def cd(fpath=nil)
       Rye::Rap.new(self[fpath])
     end
-    
+
     # Change the current umask (sort of -- works the same way as cd)
     # The default umask is 0022
     def umask=(val='0022')
       @rye_current_umask = val
       self
     end
-    
-    
+
+
     # Reconnect as another user. This is different from su=
-    # which executes subsequent commands via +su -c COMMAND USER+. 
-    # * +newuser+ The username to reconnect as 
+    # which executes subsequent commands via +su -c COMMAND USER+.
+    # * +newuser+ The username to reconnect as
     #
     # NOTE: if there is an open connection, it's disconnected
-    # but not reconnected because it's possible it wasn't 
-    # connected yet in the first place (if you create the 
+    # but not reconnected because it's possible it wasn't
+    # connected yet in the first place (if you create the
     # instance with default settings for example)
     def switch_user(newuser)
       return if newuser.to_s == self.user.to_s
@@ -287,17 +287,17 @@ module Rye
       disconnect
     end
 
-    
+
     # If STDIN.tty? is true (i.e. if we're connected to a terminal
     # with a human at the helm), this will open an SSH connection
-    # via the regular SSH command (via a call to system). This 
+    # via the regular SSH command (via a call to system). This
     # requires the SSH command-line executable (ssh).
     #
-    # If STDIN.tty? is false or +run+ is false, this will return 
-    # the SSH command (a String) that would have been run. 
-    # 
+    # If STDIN.tty? is false or +run+ is false, this will return
+    # the SSH command (a String) that would have been run.
+    #
     # NOTE: As of Rye 0.9 you can run interactive sessions with
-    # rye by calling any shell method without arguments. 
+    # rye by calling any shell method without arguments.
     #
     # e.g.
     #
@@ -315,7 +315,7 @@ module Rye
       return cmd unless run
       system(cmd)
     end
-    
+
     # Add one or more private keys to the list of key paths.
     # * +keys+ is a list of file paths to private keys
     # Returns the instance of Box
@@ -326,7 +326,7 @@ module Rye
       self # MUST RETURN self
     end
     alias :add_key :add_keys
-    
+
     # Remove one or more private keys fromt he list of key paths.
     # * +keys+ is a list of file paths to private keys
     # Returns the instance of Box
@@ -337,7 +337,7 @@ module Rye
       self # MUST RETURN self
     end
     alias :remove_key :remove_keys
-    
+
     # Return the value of uname in lowercase
     # This is a temporary fix. We can use SysInfo for this, upload
     # it, execute it directly, parse the output.
@@ -348,26 +348,26 @@ module Rye
       os &&= os.downcase
       @rye_ostype = os
     end
-    
+
     def impltype
       @rye_impltype
     end
-    
-    # Returns the hash containing the parsed output of "env" on the 
-    # remote machine. If the initialize option +:getenv+ was set to 
-    # false, this will return an empty hash. 
+
+    # Returns the hash containing the parsed output of "env" on the
+    # remote machine. If the initialize option +:getenv+ was set to
+    # false, this will return an empty hash.
     # This is a lazy loaded method so it fetches the remote envvars
-    # the first time this method is called. 
+    # the first time this method is called.
     #
     #      puts rbox.getenv['HOME']    # => "/home/gloria" (remote)
     #
     # NOTE: This method should not raise an exception under normal
-    # circumstances. 
+    # circumstances.
     #
     def getenv(key=nil)
       if @rye_getenv && @rye_getenv.empty? && self.can?(:env)
         vars = self.quietly { env } rescue []
-        vars.each do |nvpair| 
+        vars.each do |nvpair|
           # Parse "GLORIA_HOME=/gloria/lives/here" into a name/value
           # pair. The regexp ensures we split only at the 1st = sign
           n, v = nvpair.scan(/\A([\w_-]+?)=(.+)\z/).flatten
@@ -376,7 +376,7 @@ module Rye
       end
       key.nil? ? @rye_getenv : @rye_getenv[key.to_s]
     end
-    
+
     # Add an environment variable. +n+ and +v+ are the name and value.
     # Returns the instance of Rye::Box
     def setenv(n, v)
@@ -387,33 +387,33 @@ module Rye
       self
     end
     alias :add_env :setenv  # deprecated?
-    
+
     # See Rye.keys
     def keys; Rye.keys; end
-    
+
     # Returns +user@rye_host+
     def to_s; '%s@rye_%s' % [user, @rye_host]; end
-    
+
     def inspect
-      %q{#<%s:%s name=%s cwd=%s umask=%s env=%s safe=%s opts=%s keys=%s>} % 
+      %q{#<%s:%s name=%s cwd=%s umask=%s env=%s safe=%s opts=%s keys=%s>} %
       [self.class.to_s, self.host, self.nickname,
        @rye_current_working_directory, @rye_current_umask,
        (@rye_current_environment_variables || '').inspect,
        self.safe, self.opts.inspect, self.keys.inspect]
     end
-    
+
     # Compares itself with the +other+ box. If the hostnames
-    # are the same, this will return true. Otherwise false. 
+    # are the same, this will return true. Otherwise false.
     def ==(other)
       @rye_host == other.host
     end
-    
+
     # Returns the host SSH keys for this box
     def host_key
       raise "No host" unless @rye_host
       Rye.remote_host_keys(@rye_host)
     end
-    
+
     # Uses the output of "useradd -D" to determine the default home
     # directory. This returns a GUESS rather than the a user's real
     # home directory. Currently used only by authorize_keys_remote.
@@ -421,10 +421,10 @@ module Rye
     def guess_user_home(other_user=nil)
       this_user = other_user || opts[:user]
       @rye_guessed_homes ||= {}
-      
-      # A simple cache. 
+
+      # A simple cache.
       return @rye_guessed_homes[this_user] if @rye_guessed_homes.has_key?(this_user)
-      
+
       # Some junk to determine where user home directories are by default.
       # We're relying on the command "useradd -D" so this may not work on
       # different Linuxen and definitely won't work on Windows.
@@ -434,7 +434,7 @@ module Rye
       user_defaults = {}
       ostmp = self.ostype
       ostmp &&= ostype.to_s
-      
+
       if ostmp == "sunos"
         #nv.scan(/([\w_-]+?)=(.+?)\s/).each do |n, v|
         #  n = 'HOME' if n == 'basedir'
@@ -455,11 +455,11 @@ module Rye
           user_defaults[n] = v
         end
       end
-      
+
       @rye_guessed_homes[this_user] = "#{user_defaults['HOME']}/#{this_user}"
     end
-    
-    # A handler for undefined commands. 
+
+    # A handler for undefined commands.
     # Raises Rye::CommandNotFound exception.
     def method_missing(cmd, *args, &block)
       if cmd == :to_ary
@@ -479,12 +479,12 @@ module Rye
     end
     alias :execute :method_missing
 
-    # Returns the command an arguments as a String. 
+    # Returns the command an arguments as a String.
     def preview_command(*args)
       prep_args(*args).join(' ')
     end
-    
-    
+
+
     # Supply a block to be called before every command. It's called
     # with three arguments: command name, an Array of arguments, user name, hostname
     # e.g.
@@ -495,9 +495,9 @@ module Rye
       @rye_pre_command_hook = block if block
       @rye_pre_command_hook
     end
-    
+
     # Supply a block to be called every time a command receives STDOUT data.
-    # 
+    #
     # e.g.
     #     rbox.stdout_hook do |content|
     #       ...
@@ -506,17 +506,17 @@ module Rye
       @rye_stdout_hook = block if block
       @rye_stdout_hook
     end
-    
+
     # Supply a block to be called whenever there's an Exception. It's called
-    # with 1 argument: the exception class. If the exception block returns 
-    # :retry, the command will be executed again. 
+    # with 1 argument: the exception class. If the exception block returns
+    # :retry, the command will be executed again.
     #
     # e.g.
     #     rbox.exception_hook(CommandNotFound) do |ex|
     #       STDERR.puts "An error occurred: #{ex.class}"
     #       choice = Annoy.get_user_input('(S)kip  (R)etry  (A)bort: ')
     #       if choice == 'R'
-    #         :retry 
+    #         :retry
     #       elsif choice == 'S'
     #         # do nothing
     #       else
@@ -527,8 +527,8 @@ module Rye
       @rye_exception_hook[klass] = block if block
       @rye_exception_hook[klass]
     end
-    
-    # Execute a block in the context of an instance of Rye::Box. 
+
+    # Execute a block in the context of an instance of Rye::Box.
     #
     #     rbox = Rye::Box.new
     #
@@ -545,13 +545,13 @@ module Rye
     #       ls :l file
     #     end
     #
-    # Returns the return value of the block. 
+    # Returns the return value of the block.
     #
     def batch(*args, &block)
       self.instance_exec(*args, &block)
     end
-    
-    # Like batch, except it disables safe mode before executing the block. 
+
+    # Like batch, except it disables safe mode before executing the block.
     # After executing the block, safe mode is returned back to whichever
     # state it was previously in. In other words, this method won't enable
     # safe mode if it was already disabled.
@@ -563,7 +563,7 @@ module Rye
       ret
     end
     alias_method :wildly, :unsafely
-    
+
     # See unsafely (except in reverse)
     def safely(*args, &block)
       previous_state = @rye_safe
@@ -572,13 +572,13 @@ module Rye
       @rye_safe = previous_state
       ret
     end
-    
-    # Like batch, except it enables quiet mode before executing the block. 
+
+    # Like batch, except it enables quiet mode before executing the block.
     # After executing the block, quiet mode is returned back to whichever
     # state it was previously in. In other words, this method won't enable
     # quiet mode if it was already disabled.
     #
-    # In quiet mode, the pre and post command hooks are not called. This 
+    # In quiet mode, the pre and post command hooks are not called. This
     # is used internally when calling commands like +ls+ to check whether
     # a file path exists (to prevent polluting the logs).
     def quietly(*args, &block)
@@ -588,10 +588,10 @@ module Rye
       @rye_quiet = previous_state
       ret
     end
-    
+
     # Like batch, except it enables sudo mode before executing the block.
-    # If the user is already root, this has no effect. Otherwise all 
-    # commands executed in the block will run via sudo. 
+    # If the user is already root, this has no effect. Otherwise all
+    # commands executed in the block will run via sudo.
     #
     # If no block is specified then sudo is called just like a regular
     # command.
@@ -603,10 +603,10 @@ module Rye
         enable_sudo
         ret = self.instance_exec *args, &block
         @rye_sudo = previous_state
-        ret  
+        ret
       end
     end
-    
+
     # instance_exec for Ruby 1.8 written by Mauricio Fernandez
     # http://eigenclass.org/hiki/instance_exec
     if RUBY_VERSION =~ /1.8/
@@ -623,33 +623,33 @@ module Rye
         ret
       end
     end
-    
+
     # Supply a block to be called after every command. It's called
     # with one argument: an instance of Rye::Rap.
     #
-    # When this block is supplied, the command does not raise an 
+    # When this block is supplied, the command does not raise an
     # exception when the exit code is greater than 0 (the typical
     # behavior) so the block needs to check the Rye::Rap object to
-    # determine whether an exception should be raised. 
+    # determine whether an exception should be raised.
     def post_command_hook(&block)
       @rye_post_command_hook = block if block
       @rye_post_command_hook
     end
 
-    
-    
+
+
     # Open an SSH session with +@rye_host+. This called automatically
     # when you the first comamnd is run if it's not already connected.
     # Raises a Rye::NoHost exception if +@rye_host+ is not specified.
-    # Will attempt a password login up to 3 times if the initial 
-    # authentication fails. 
+    # Will attempt a password login up to 3 times if the initial
+    # authentication fails.
     # * +reconnect+ Disconnect first if already connected. The default
-    # is true. When set to false, connect will do nothing if already 
-    # connected. 
+    # is true. When set to false, connect will do nothing if already
+    # connected.
     def connect(reconnect=true)
       raise Rye::NoHost unless @rye_host
       return if @rye_ssh && !reconnect
-      disconnect if @rye_ssh 
+      disconnect if @rye_ssh
       if @rye_via
         debug "Opening connection to #{@rye_host} as #{@rye_user}, via #{@rye_via.host}"
       else
@@ -664,9 +664,9 @@ module Rye
           # it returns the local port used
           @rye_localport = @rye_via.fetch_port(@rye_host, @rye_opts[:port].nil? ? 22 : @rye_opts[:port] )
           debug "fetched localport #{@rye_localport}"
-          @rye_ssh = Net::SSH.start("localhost", @rye_user, @rye_opts.merge(:port => @rye_localport) || {}) 
+          @rye_ssh = Net::SSH.start("localhost", @rye_user, @rye_opts.merge(:port => @rye_localport) || {})
         else
-          @rye_ssh = Net::SSH.start(@rye_host, @rye_user, @rye_opts || {}) 
+          @rye_ssh = Net::SSH.start(@rye_host, @rye_user, @rye_opts || {})
         end
       rescue Net::SSH::HostKeyMismatch => ex
         STDERR.puts ex.message
@@ -678,7 +678,7 @@ module Rye
 
         @rye_opts[:auth_methods] ||= []
 
-        # Raise Net::SSH::AuthenticationFailed if publickey is the 
+        # Raise Net::SSH::AuthenticationFailed if publickey is the
         # only auth method
         if @rye_opts[:auth_methods] == ["publickey"]
           raise ex
@@ -691,49 +691,51 @@ module Rye
           raise ex
         end
       end
-      
+
       # We add :auth_methods (a Net::SSH joint) to force asking for a
       # password if the initial (key-based) authentication fails. We
       # need to delete the key from @rye_opts otherwise it lingers until
       # the next connection (if we switch_user is called for example).
       @rye_opts.delete :auth_methods if @rye_opts.has_key?(:auth_methods)
-      
+
       self
     end
-    
-    # Close the SSH session  with +@rye_host+. This is called 
-    # automatically at exit if the connection is open. 
+
+    # Close the SSH session  with +@rye_host+. This is called
+    # automatically at exit if the connection is open.
     def disconnect
       return unless @rye_ssh && !@rye_ssh.closed?
       begin
         if @rye_ssh.busy?;
           info "Is something still running? (ctrl-C to exit)"
-          Timeout::timeout(10) do
-            @rye_ssh.loop(0.3) { @rye_ssh.busy?; }
+          @rye_ssh.loop(10) { @rye_ssh.busy?; }
+        end
+        if @rye_ssh.busy?
+          error "Rye::Box: Disconnect timeout"
+        else
+          debug "Closing connection to #{@rye_ssh.host}"
+          @rye_ssh.close
+          if @rye_via
+            debug "disconnecting Hop #{@rye_via.host}"
+            @rye_via.disconnect
           end
-        end
-        debug "Closing connection to #{@rye_ssh.host}"
-        @rye_ssh.close
-        if @rye_via
-          debug "disconnecting Hop #{@rye_via.host}"
-          @rye_via.disconnect
-        end
-      rescue SystemCallError, Timeout::Error => ex
+      end
+    rescue SystemCallError => ex
         error "Rye::Box: Disconnect timeout (#{ex.message})"
         debug ex.backtrace
       rescue Interrupt
         debug "Exiting..."
       end
     end
-    
-    
+
+
   private
-      
+
     def debug(msg="unknown debug msg"); @rye_debug.puts msg if @rye_debug; end
     def error(msg="unknown error msg"); @rye_error.puts msg if @rye_error; end
     def pinfo(msg="unknown info msg"); @rye_info.print msg if @rye_info; end
     def info(msg="unknown info msg"); @rye_info.puts msg if @rye_info; end
-    
+
     # Add the current environment variables to the beginning of +cmd+
     def prepend_env(cmd)
       return cmd unless @rye_current_environment_variables.is_a?(Hash)
@@ -743,12 +745,12 @@ module Rye
       end
       [env, cmd].join(' ')
     end
-    
+
 
 
     # Execute a command over SSH
     #
-    # * +args+ is a command name and list of arguments. 
+    # * +args+ is a command name and list of arguments.
     # The command name is the literal name of the command
     # that will be executed in the remote shell. The arguments
     # will be thoroughly escaped and passed to the command.
@@ -761,60 +763,60 @@ module Rye
     #     $ ls -l 'arg1' 'arg2'
     #
     # This method will try to connect to the host automatically
-    # but if it fails it will raise a Rye::NotConnected exception. 
-    # 
+    # but if it fails it will raise a Rye::NotConnected exception.
+    #
     def run_command(*args, &blk)
       debug "run_command"
-      
+
       cmd, args = prep_args(*args)
-      
+
       #p [:run_command, cmd, blk.nil?]
-      
+
       connect if !@rye_ssh || @rye_ssh.closed?
       raise Rye::NotConnected, @rye_host unless @rye_ssh && !@rye_ssh.closed?
-      
+
       cmd_clean = Rye.escape(@rye_safe, cmd, args)
-      
+
       # This following is the command we'll actually execute. cmd_clean
       # can be used for logging, otherwise the output is confusing.
       cmd_internal = prepend_env(cmd_clean)
-      
-      # Add the current working directory before the command if supplied. 
+
+      # Add the current working directory before the command if supplied.
       # The command will otherwise run in the user's home directory.
       if @rye_current_working_directory
         cwd = Rye.escape(@rye_safe, 'cd', @rye_current_working_directory)
         cmd_internal = '(%s; %s)' % [cwd, cmd_internal]
       end
-      
+
       # ditto (same explanation as cwd)
       if @rye_current_umask
         cwd = Rye.escape(@rye_safe, 'umask', @rye_current_umask)
         cmd_internal = [cwd, cmd_internal].join(' && ')
       end
-      
+
       ## NOTE: Do not raise a CommandNotFound exception in this method.
       # We want it to be possible to define methods to a single instance
       # of Rye::Box. i.e. def rbox.rm()...
       # can? returns the methods in Rye::Cmd so it would incorrectly
       # return false. We could use self.respond_to? but it's possible
       # to get a name collision. I could write a work around but I think
-      # this is good enough for now. 
+      # this is good enough for now.
       ## raise Rye::CommandNotFound unless self.can?(cmd)
-      
+
       begin
         debug "COMMAND: #{cmd_internal}"
 
         if !@rye_quiet && @rye_pre_command_hook.is_a?(Proc)
-          @rye_pre_command_hook.call(cmd_clean, user, host, nickname) 
+          @rye_pre_command_hook.call(cmd_clean, user, host, nickname)
         end
-        
+
         rap = Rye::Rap.new(self)
         rap.cmd = cmd_clean
-        
+
         channel = net_ssh_exec!(cmd_internal, &blk)
         channel[:stderr].position = 0
         channel[:stdout].position = 0
-        
+
         if channel[:exception]
           rap = channel[:exception].rap
         else
@@ -823,15 +825,15 @@ module Rye
           rap.add_exit_status(channel[:exit_status])
           rap.exit_signal = channel[:exit_signal]
         end
-        
+
         debug "RESULT: %s " % [rap.inspect]
-        
+
         # It seems a convention for various commands to return -1
-        # when something only mildly concerning happens. (ls even 
+        # when something only mildly concerning happens. (ls even
         # returns -1 for apparently no reason sometimes). Anyway,
         # the real errors are the ones that are greater than zero.
         raise Rye::Err.new(rap) if rap.exit_status != 0
-        
+
       rescue Exception => ex
         return rap if @rye_quiet
         choice = nil
@@ -855,24 +857,24 @@ module Rye
           raise ex, ex.message
         end
       end
-      
+
       if !@rye_quiet && @rye_post_command_hook.is_a?(Proc)
         @rye_post_command_hook.call(rap)
       end
-      
+
       rap
     end
     alias :__allow :run_command
-    
+
     # Takes a list of arguments appropriate for run_command or
-    # preview_command and returns: [cmd, args]. 
+    # preview_command and returns: [cmd, args].
     # Single character symbols with be converted to command line
     # switches. Example:   +:l+ becomes +-l+
     def prep_args(*args)
       args = args.flatten.compact
       args = args.first.to_s.split(/\s+/) if args.size == 1
       cmd = sudo? ? :sudo : args.shift
-      
+
       # Symbols to switches. :l -> -l, :help -> --help
       args.collect! do |a|
         if a.is_a?(Symbol)
@@ -882,17 +884,17 @@ module Rye
       end
       [cmd, args]
     end
-    
+
     def net_ssh_exec!(cmd, &blk)
       debug ":net_ssh_exec #{cmd} (has blk: #{!blk.nil?}; pty: #{@rye_pty}; shell: #{@rye_shell})"
-      
+
       pty_opts =   { :term => "xterm",
                               :chars_wide  => 80,
                               :chars_high  => 24,
                               :pixels_wide => 640,
                               :pixels_high => 480,
                               :modes       => {} }
-      
+
       channel = @rye_ssh.open_channel do |channel|
         if self.rye_shell && blk.nil?
           channel.request_pty(pty_opts) do |ch,success|
@@ -904,19 +906,19 @@ module Rye
         channel[:state] = :start_session
         channel[:block] = blk
       end
-      
+
       @rye_channels ||= []
       @rye_channels << channel
-      
+
       @rye_ssh.loop(0.1) do
         break if channel.nil? || !channel.active?
         !channel.eof?   # otherwise keep returning true
       end
-      
+
       channel
     end
-    
-    
+
+
     def state_wait_for_command(channel)
       debug :wait_for_command
     end
@@ -924,10 +926,10 @@ module Rye
     def state_start_session(channel)
       debug "#{:start_session} [blk: #{!channel[:block].nil?}] [pty: #{@rye_pty}] [shell: #{@rye_shell}]"
       channel[:state] = nil
-      channel[:state] = :run_block if channel[:block] 
+      channel[:state] = :run_block if channel[:block]
       channel[:state] = :await_response if @rye_pty
     end
-    
+
     def state_await_response(channel)
       debug :await_response
       @await_response_counter ||= 0
@@ -939,17 +941,17 @@ module Rye
       end
       @await_response_counter += 1
     end
-    
+
     def state_read_response(channel)
       debug :read_response
       if channel[:stdout].available > 0 || channel[:stderr].available > 0
-        
+
         stdout = channel[:stdout].read if channel[:stdout].available > 0
         stderr = channel[:stderr].read if channel[:stderr].available > 0
-        
+
         print stdout if stdout
         print stderr if stderr
-        
+
         if channel[:stack].empty?
           channel[:state] = :await_input
         elsif channel[:stdout].available > 0 || channel[:stderr].available > 0
@@ -960,7 +962,7 @@ module Rye
       else
         channel[:state] = :await_response
       end
-      
+
     end
 
     def state_send_data(channel)
@@ -970,7 +972,7 @@ module Rye
       channel[:state] = :await_response
       channel.send_data("#{cmd}\n") unless channel.eof?
     end
-    
+
     def state_await_input(channel)
       debug :await_input
         if channel[:stdout].available > 0
@@ -984,17 +986,17 @@ module Rye
           begin
             list = self.commands.sort
 
-            comp = proc { |s| 
+            comp = proc { |s|
               # TODO: Something here for files
-              list.grep( /^#{Regexp.escape(s)}/ ) 
+              list.grep( /^#{Regexp.escape(s)}/ )
             }
 
             Readline.completion_append_character = " "
             Readline.completion_proc = comp
-            
+
             ret = Readline.readline(channel[:prompt] || '', true)
             #ret = STDIN.gets
-            
+
             if ret.nil?
               channel[:state] = :exit
             else
@@ -1007,7 +1009,7 @@ module Rye
           channel[:prompt] = nil
         end
     end
-    
+
     def state_ignore_response(channel)
       debug :ignore_response
       @ignore_response_counter ||= 0
@@ -1021,7 +1023,7 @@ module Rye
       end
       @ignore_response_counter += 1
     end
-    
+
     def state_exit(channel)
       debug :exit_state
       channel[:state] = nil
@@ -1032,7 +1034,7 @@ module Rye
         channel.eof!
       end
     end
-    
+
     # TODO: implement callback in create_channel Proc
     ##def state_handle_error(channel)
     ##  debug :handle_error
@@ -1044,7 +1046,7 @@ module Rye
     ##    channel.eof!
     ##  end
     ##end
-    
+
 
     def state_run_block(channel)
       debug :run_block
@@ -1058,26 +1060,26 @@ module Rye
       end
       channel[:state] = :exit
     end
-    
+
     def create_channel()
       Proc.new do |channel,success|
         channel[:stdout  ] = Net::SSH::Buffer.new
         channel[:stderr  ] = Net::SSH::Buffer.new
         channel[:stack] ||= []
-        channel.on_close                  { |ch|  
+        channel.on_close                  { |ch|
           channel[:handler] = ":on_close"
         }
-        channel.on_data                   { |ch, data| 
+        channel.on_data                   { |ch, data|
           channel[:handler] = ":on_data"
           @rye_stdout_hook.call(data, user, host, nickname) if !@rye_pty && !@rye_quiet && @rye_stdout_hook.kind_of?(Proc)
           if rye_pty && data =~ /password/i
             channel[:prompt] = data
             channel[:state] = :await_input
           else
-            channel[:stdout].append(data) 
+            channel[:stdout].append(data)
           end
         }
-        channel.on_extended_data          { |ch, type, data| 
+        channel.on_extended_data          { |ch, type, data|
           channel[:handler] = ":on_extended_data"
           if rye_pty && data =~ /\Apassword/i
             channel[:prompt] = data
@@ -1086,16 +1088,16 @@ module Rye
             channel[:stderr].append(data)
           end
         }
-        channel.on_request("exit-status") { |ch, data| 
+        channel.on_request("exit-status") { |ch, data|
           channel[:handler] = ":on_request (exit-status)"
-          channel[:exit_status] = data.read_long 
+          channel[:exit_status] = data.read_long
         }
         channel.on_request("exit-signal") do |ch, data|
           channel[:handler] = ":on_request (exit-signal)"
           # This should be the POSIX SIGNAL that ended the process
           channel[:exit_signal] = data.read_long
         end
-        channel.on_process                { 
+        channel.on_process                {
           channel[:handler] = :on_process
           STDERR.print channel[:stderr].read if channel[:stderr].available > 0
           begin
@@ -1107,11 +1109,11 @@ module Rye
         }
       end
     end
-    
-    
-    
+
+
+
     # * +direction+ is one of :upload, :download
-    # * +recursive+ should be true for directories and false for files. 
+    # * +recursive+ should be true for directories and false for files.
     # * +files+ is an Array of file paths, the content is direction specific.
     # For downloads, +files+ is a list of files to download. The last element
     # must be the local directory to download to. If downloading a single file
@@ -1120,33 +1122,33 @@ module Rye
     # the directory to upload to. If uploading a single file, the last element
     # can be a file path. The list of files can also include StringIO objects.
     # For both uploads and downloads, the target directory will be created if
-    # it does not exist, but only when multiple files are being transferred. 
+    # it does not exist, but only when multiple files are being transferred.
     # This method will fail early if there are obvious problems with the input
-    # parameters. An exception is raised and no files are transferred. 
+    # parameters. An exception is raised and no files are transferred.
     # Uploads always return nil. Downloads return nil or a StringIO object if
-    # one is specified for the target. 
+    # one is specified for the target.
     def net_scp_transfer!(direction, recursive, *files)
-      
+
       unless [:upload, :download].member?(direction.to_sym)
-        raise "Must be one of: upload, download" 
+        raise "Must be one of: upload, download"
       end
-      
+
       if @rye_current_working_directory
         debug "CWD (#{@rye_current_working_directory})"
       end
-      
+
       files = [files].flatten.compact || []
 
       # We allow a single file to be downloaded into a StringIO object
-      # but only when no target has been specified. 
-      if direction == :download 
+      # but only when no target has been specified.
+      if direction == :download
         if files.size == 1
           debug "Created StringIO for download"
           target = StringIO.new
         else
           target = files.pop   # The last path is the download target.
         end
-        
+
       elsif direction == :upload
 #        p :UPLOAD, @rye_templates
         raise "Cannot upload to a StringIO object" if target.is_a?(StringIO)
@@ -1156,17 +1158,17 @@ module Rye
         else
           target = files.pop
         end
-        
+
         # Expand fileglobs (e.g. path/*.rb becomes [path/1.rb, path/2.rb]).
         # This should happen after checking files.size to determine the target
         unless @rye_safe
-          files.collect! { |file| 
-            file.is_a?(StringIO) ? file : Dir.glob(File.expand_path(file)) 
+          files.collect! { |file|
+            file.is_a?(StringIO) ? file : Dir.glob(File.expand_path(file))
           }
-          files.flatten! 
+          files.flatten!
         end
       end
-              
+
       # Fail early. We check whether the StringIO object is available to read
       files.each do |file|
         if file.is_a?(StringIO)
@@ -1176,16 +1178,16 @@ module Rye
           file.rewind if file.eof?
         end
       end
-      
+
       debug "FILES: " << files.join(', ')
-      
+
       # Make sure the target directory exists. We can do this only when
       # there's more than one file because "target" could be a file name
       if files.size > 1 && !target.is_a?(StringIO)
         debug "CREATING TARGET DIRECTORY: #{target}"
         self.mkdir(:p, target) unless self.file_exists?(target)
       end
-      
+
       Net::SCP.start(@rye_host, @rye_user, @rye_opts || {}) do |scp|
         transfers = []
         prev = ""
@@ -1203,12 +1205,10 @@ module Rye
         end
         transfers.each { |t| t.wait }   # Run file transfers in parallel
       end
-      
+
       target.is_a?(StringIO) ? target : nil
     end
-    
+
 
   end
 end
-
-

--- a/lib/rye/hop.rb
+++ b/lib/rye/hop.rb
@@ -7,7 +7,7 @@ module Rye
 
   # = Rye::Hop
   #
-  # The Rye::Hop class represents a machine. 
+  # The Rye::Hop class represents a machine.
   # This class allows boxes to by accessed via it.
   #
   #     rhop = Rye::Hop.new('firewall.lan')
@@ -22,9 +22,9 @@ module Rye
   # * When anything confusing happens, enable debug in initialize
   # by passing :debug => STDERR. This will output Rye debug info
   # as well as Net::SSH info. This is VERY helpful for figuring
-  # out why some command is hanging or otherwise acting weird. 
+  # out why some command is hanging or otherwise acting weird.
   # * If a remote command is hanging, it's probably because a
-  # Net::SSH channel is waiting on_extended_data (a prompt). 
+  # Net::SSH channel is waiting on_extended_data (a prompt).
   #++
   class Hop
 
@@ -40,7 +40,7 @@ module Rye
     def opts; @rye_opts; end
     def user; @rye_user; end
     def root?; user.to_s == "root" end
-    
+
     def nickname; @rye_nickname || host; end
     def via; @rye_via; end
 
@@ -48,12 +48,12 @@ module Rye
     def host=(val); @rye_host = val; end
     def opts=(val); @rye_opts = val; end
 
-    
+
     def via?; !@rye_via.nil?; end
     def info?; !@rye_info.nil?; end
     def debug?; !@rye_debug.nil?; end
     def error?; !@rye_error.nil?; end
-    
+
 
     # A Hash. The keys are exception classes, the values are Procs to execute
     def exception_hook=(val); @rye_exception_hook = val; end
@@ -75,20 +75,20 @@ module Rye
     # * :templates => the template engine to use for uploaded files. One of: :erb (default)
     # * :sudo => Run all commands via sudo (default: false)
     #
-    # NOTE: +opts+ can also contain any parameter supported by 
+    # NOTE: +opts+ can also contain any parameter supported by
     # Net::SSH.start that is not already mentioned above.
     #
     def initialize(host, opts={})
       ssh_opts = ssh_config_options(host)
       @rye_exception_hook = {}
       @rye_host = host
-      
+
       if opts[:user]
         @rye_user = opts[:user]
       else
         @rye_user = ssh_opts[:user] || Rye.sysinfo.user
       end
-      
+
       # These opts are use by Rye::Box and also passed to
       # Net::SSH::Gateway (and Net::SSH)
       @rye_opts = {
@@ -106,7 +106,7 @@ module Rye
       @next_port = MAX_PORT
 
       # Close the SSH session before Ruby exits. This will do nothing
-      # if disconnect has already been called explicitly. 
+      # if disconnect has already been called explicitly.
       at_exit { self.disconnect }
 
       # Properly handle whether the opt :via is a +Rye::Hop+ or a +String+
@@ -114,41 +114,41 @@ module Rye
       via_hop(@rye_opts.delete(:via))
 
       # @rye_opts gets sent to Net::SSH so we need to remove the keys
-      # that are not meant for it. 
+      # that are not meant for it.
       @rye_safe, @rye_debug = @rye_opts.delete(:safe), @rye_opts.delete(:debug)
       @rye_info, @rye_error = @rye_opts.delete(:info), @rye_opts.delete(:error)
       @rye_getenv = {} if @rye_opts.delete(:getenv) # Enable getenv with a hash
       @rye_ostype, @rye_impltype = @rye_opts.delete(:ostype), @rye_opts.delete(:impltype)
       @rye_quiet, @rye_sudo = @rye_opts.delete(:quiet), @rye_opts.delete(:sudo)
       @rye_templates = @rye_opts.delete(:templates)
-      
-      # Store the state of the terminal 
+
+      # Store the state of the terminal
       @rye_stty_save = `stty -g`.chomp rescue nil
-      
+
       unless @rye_templates.nil?
         require @rye_templates.to_s   # should be :erb
       end
-      
+
       @rye_opts[:logger] = Logger.new(@rye_debug) if @rye_debug # Enable Net::SSH debugging
       @rye_opts[:keys] = [@rye_opts[:keys]].flatten.compact
-      
+
       # Just in case someone sends a true value rather than IO object
       @rye_debug = STDERR if @rye_debug == true || DEBUG
       @rye_error = STDERR if @rye_error == true
       @rye_info = STDOUT if @rye_info == true
-      
+
       # Add the given private keys to the keychain that will be used for @rye_host
       add_keys(@rye_opts[:keys])
-      
+
       # From: capistrano/lib/capistrano/cli.rb
       STDOUT.sync = true # so that Net::SSH prompts show up
-      
+
       debug "ssh-agent info: #{Rye.sshagent_info.inspect}"
       debug @rye_opts.inspect
     end
-    
-    # * +hops+ Rye::Hop objects will be added directly 
-    # to the set. Hostnames will be used to create new instances of Rye::Hop 
+
+    # * +hops+ Rye::Hop objects will be added directly
+    # to the set. Hostnames will be used to create new instances of Rye::Hop
     # h1 = Rye::Hop.new "host1"
     # h1.via_hop "host2", :user => "service_user"
     #
@@ -159,7 +159,7 @@ module Rye
     # h1.via_hop h2
     #
     def via_hop(*hops)
-      hops = hops.flatten.compact 
+      hops = hops.flatten.compact
       if hops.first.nil?
         return @rye_via
       elsif hops.first.is_a?(Rye::Hop)
@@ -185,19 +185,19 @@ module Rye
       else
         port_used = localport
       end
-      # i would like to check if the port and host 
-      # are already an active_locals forward, but that 
+      # i would like to check if the port and host
+      # are already an active_locals forward, but that
       # info does not get returned, and trusting the localport
       # is not enough information, so lets just set up a new one
       @rye_ssh.forward.local(port_used, host, port)
       return port_used
     end
-    
+
     # Parse SSH config files for use with Net::SSH
     def ssh_config_options(host)
       return Net::SSH::Config.for(host)
     end
-    
+
     # Add one or more private keys to the list of key paths.
     # * +keys+ is a list of file paths to private keys
     # Returns the instance of Box
@@ -219,14 +219,14 @@ module Rye
       self # MUST RETURN self
     end
     alias :remove_key :remove_keys
-    
+
     # Reconnect as another user. This is different from su=
-    # which executes subsequent commands via +su -c COMMAND USER+. 
-    # * +newuser+ The username to reconnect as 
+    # which executes subsequent commands via +su -c COMMAND USER+.
+    # * +newuser+ The username to reconnect as
     #
     # NOTE: if there is an open connection, it's disconnected
-    # but not reconnected because it's possible it wasn't 
-    # connected yet in the first place (if you create the 
+    # but not reconnected because it's possible it wasn't
+    # connected yet in the first place (if you create the
     # instance with default settings for example)
     def switch_user(newuser)
       return if newuser.to_s == self.user.to_s
@@ -238,15 +238,15 @@ module Rye
     # Open an SSH session with +@rye_host+. This called automatically
     # when you the first comamnd is run if it's not already connected.
     # Raises a Rye::NoHost exception if +@rye_host+ is not specified.
-    # Will attempt a password login up to 3 times if the initial 
-    # authentication fails. 
+    # Will attempt a password login up to 3 times if the initial
+    # authentication fails.
     # * +reconnect+ Disconnect first if already connected. The default
-    # is true. When set to false, connect will do nothing if already 
-    # connected. 
+    # is true. When set to false, connect will do nothing if already
+    # connected.
     def connect(reconnect=true)
       raise Rye::NoHost unless @rye_host
       return if @rye_ssh && !reconnect
-      disconnect if @rye_ssh 
+      disconnect if @rye_ssh
       if @rye_via
         debug "Opening connection to #{@rye_host} as #{@rye_user}, via #{@rye_via.host}"
       else
@@ -260,9 +260,9 @@ module Rye
           # tell the +Rye::Hop+ what and where to setup,
           # it returns the local port used
           @rye_localport = @rye_via.fetch_port(@rye_host, @rye_opts[:port].nil? ? 22 : @rye_opts[:port] )
-          @rye_ssh = Net::SSH.start("localhost", @rye_user, @rye_opts.merge(:port => @rye_localport) || {}) 
+          @rye_ssh = Net::SSH.start("localhost", @rye_user, @rye_opts.merge(:port => @rye_localport) || {})
         else
-          @rye_ssh = Net::SSH.start(@rye_host, @rye_user, @rye_opts || {}) 
+          @rye_ssh = Net::SSH.start(@rye_host, @rye_user, @rye_opts || {})
         end
         debug "starting the port forward thread"
         port_loop
@@ -288,20 +288,20 @@ module Rye
           raise ex
         end
       end
-      
+
       # We add :auth_methods (a Net::SSH joint) to force asking for a
       # password if the initial (key-based) authentication fails. We
       # need to delete the key from @rye_opts otherwise it lingers until
       # the next connection (if we switch_user is called for example).
       @rye_opts.delete :auth_methods if @rye_opts.has_key?(:auth_methods)
-      
+
       self
     end
 
     # Cancel the port forward on all active local forwards
     def remove_hops!
       return unless @rye_ssh && @rye_ssh.forward.active_locals.count > 0
-      @rye_ssh.forward.active_locals.each {|fport, fhost| 
+      @rye_ssh.forward.active_locals.each {|fport, fhost|
         @rye_ssh.forward.cancel_local(fport, fhost)
       }
       if !@rye_ssh.channels.empty?
@@ -311,9 +311,9 @@ module Rye
       end
       return @rye_ssh.forward.active_locals.count
     end
-    
-    # Close the SSH session  with +@rye_host+. This is called 
-    # automatically at exit if the connection is open. 
+
+    # Close the SSH session  with +@rye_host+. This is called
+    # automatically at exit if the connection is open.
     def disconnect
       return unless @rye_ssh && !@rye_ssh.closed?
       begin
@@ -323,51 +323,53 @@ module Rye
         @rye_port_thread.kill
         if @rye_ssh.busy?;
           info "Is something still running? (ctrl-C to exit)"
-          Timeout::timeout(10) do
-            @rye_ssh.loop(0.3) { @rye_ssh.busy?; }
+          @rye_ssh.loop(10) { @rye_ssh.busy?; }
+        end
+        if @rye_ssh.busy?
+          error "Rye::Hop: Disconnect timeout"
+        else
+          debug "Closing connection to #{@rye_ssh.host}"
+          @rye_ssh.close
+          if @rye_via
+            debug "disconnecting Hop #{@rye_via.host}"
+            @rye_via.disconnect
           end
         end
-        debug "Closing connection to #{@rye_ssh.host}"
-        @rye_ssh.close
-        if @rye_via
-          debug "disconnecting Hop #{@rye_via.host}"
-          @rye_via.disconnect
-        end
-      rescue SystemCallError, Timeout::Error => ex
+      rescue SystemCallErro => ex
         error "Rye::Hop: Disconnect timeout (#{ex.message})"
         debug ex.backtrace
       rescue Interrupt
         debug "Exiting..."
       end
     end
-    
+
     # See Rye.keys
     def keys; Rye.keys; end
-    
+
     # Returns +user@rye_host+
     def to_s; '%s@rye_%s' % [user, @rye_host]; end
-    
+
     def inspect
-      %q{#<%s:%s name=%s cwd=%s umask=%s env=%s via=%s opts=%s keys=%s>} % 
+      %q{#<%s:%s name=%s cwd=%s umask=%s env=%s via=%s opts=%s keys=%s>} %
       [self.class.to_s, self.host, self.nickname,
        @rye_current_working_directory, @rye_current_umask,
        (@rye_current_environment_variables || '').inspect,
        (@rye_via || '').inspect,
        self.opts.inspect, self.keys.inspect]
     end
-    
+
     # Compares itself with the +other+ box. If the hostnames
-    # are the same, this will return true. Otherwise false. 
+    # are the same, this will return true. Otherwise false.
     def ==(other)
       @rye_host == other.host
     end
-    
+
     # Returns the host SSH keys for this box
     def host_key
       raise "No host" unless @rye_host
       Rye.remote_host_keys(@rye_host)
     end
-    
+
   private
     # Kicks off the thread that maintains the forwards
     # if additional +Rye::Box+es add this +Rye::Hop+ as their via,
@@ -398,13 +400,12 @@ module Rye
         next_port()
       end
     end
-      
+
     def debug(msg="unknown debug msg"); @rye_debug.puts msg if @rye_debug; end
     def error(msg="unknown error msg"); @rye_error.puts msg if @rye_error; end
     def pinfo(msg="unknown info msg"); @rye_info.print msg if @rye_info; end
     def info(msg="unknown info msg"); @rye_info.puts msg if @rye_info; end
-    
+
   end
 
 end
-

--- a/lib/rye/hop.rb
+++ b/lib/rye/hop.rb
@@ -335,7 +335,7 @@ module Rye
             @rye_via.disconnect
           end
         end
-      rescue SystemCallErro => ex
+      rescue SystemCallError => ex
         error "Rye::Hop: Disconnect timeout (#{ex.message})"
         debug ex.backtrace
       rescue Interrupt


### PR DESCRIPTION
Removing due to http://blog.headius.com/2008/02/ruby-threadraise-threadkill-timeoutrb.html
and http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/

We're having some instability in sidekiq production and it may be related to timeout usage.
